### PR TITLE
Bump library version.

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=TSL2561 Arduino Library
-version=1.0.0
+version=1.1.0
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Arduino library for using the TSL2561 Luminosity sensor


### PR DESCRIPTION
This is to bumping library version, so managers like PlatformIO would rebuild the lib. 

Currently, PlatformIO keeps local copy of "1.0.0" built more than a year ago, and that version doesn't include <ESP8266> related patch introduced after library has been built. 

For next time, any time library itself is updated, library info should be updated too, so changes would be picked up.
